### PR TITLE
Complex topics trigger a Protocol.UndefinedError

### DIFF
--- a/test/pg2pubsub_test.exs
+++ b/test/pg2pubsub_test.exs
@@ -4,7 +4,7 @@ defmodule Pg2PubSubTest do
 
   setup do
     :pg2.which_groups
-    |> Enum.map fn (x) -> :pg2.delete(x) end
+    |> Enum.map(fn (x) -> :pg2.delete(x) end)
     :ok
   end
 
@@ -41,5 +41,14 @@ defmodule Pg2PubSubTest do
 
     assert_receive :foo
     refute_receive :foo # check only received once
+  end
+
+  test "supports more complex topics than just strings" do
+    Pg2PubSub.subscribe({:context, "bar"})
+
+    Pg2PubSub.publish({:context, "bar"}, :bar)
+    Pg2PubSub.unsubscribe({:context, "bar"})
+
+    assert_receive :bar
   end
 end


### PR DESCRIPTION
Thanks for this small but useful library. I write something very similar of my own and thought about publishing it. But then I stumbled upon your project which completely satisfies my needs.

I came across an issue. I need to have more complex topics than just plain string. Unfortunately that produced an error:

```
[error] an exception was raised:
    ** (Protocol.UndefinedError) protocol String.Chars not implemented for {"job", 155}
        (elixir) lib/string/chars.ex:3: String.Chars.impl_for!/1
        (elixir) lib/string/chars.ex:17: String.Chars.to_string/1
        (pg2pubsub) lib/pg2pubsub.ex:29: Pg2PubSub.subscribe/1
        (thumbs_up_ui) web/channels/job_channel.ex:7: ThumbsUpUi.JobChannel.join/3
        (phoenix) lib/phoenix/channel/server.ex:169: Phoenix.Channel.Server.init/1
        (stdlib) gen_server.erl:328: :gen_server.init_it/6
        (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```

Here is a fix to this problem 😄 
